### PR TITLE
Minor Issue Fixes

### DIFF
--- a/ExportNICSettings.ps1
+++ b/ExportNICSettings.ps1
@@ -178,7 +178,7 @@ $VMIdentifier = $_
 $GetVMSettingsURL = $baseURL+"vpgSettings/"+$VPGSettingsIdentifier+"/vms/"+$VMIdentifier
 $GetVMSettings = Invoke-RestMethod -Method Get -Uri $GetVMSettingsURL -TimeoutSec 100 -Headers $zertoSessionHeader_json -ContentType $TypeJSON
 # Getting the VM name and disk usage
-$VMNameArray = $vmListarray | where-object {$_.VmIdentifier -eq $VMIdentifier} | Select-Object *
+$VMNameArray = $vmListarray | where-object {$_.VmIdentifier -eq $VMIdentifier} | Select-Object * -first 1
 $VMName = $VMNameArray.VmName
 #------------------------------------------------------------------------------#
 # Get VM Nic settings for the current VPG

--- a/RE-configureNIC's.ps1
+++ b/RE-configureNIC's.ps1
@@ -139,7 +139,7 @@ if ($ValidVPGSettingsIdentifier -eq $true)
 # Getting ZVR IDs for the VPG
 #------------------------------------------------------------------------------#
 $VPGSettingsURL = $baseURL+"vpgSettings/"+$VPGSettingsIdentifier
-$VPGSettings = Invoke-RestMethod -Uri $VPGSettingsURL -Headers $zertoSessionHeader -ContentType $TypeJSON
+$VPGSettings = Invoke-RestMethod -Uri $VPGSettingsURL -Headers $zertoSessionHeader_json -ContentType $TypeJSON
 # Getting recovery site ID (needed anyway for network settings)
 $VPGRecoverySiteIdentifier = $VPGSettings.Basic.RecoverySiteIdentifier
 # Getting network info


### PR DESCRIPTION
In the export script, when a VM is being protected by more than one VPG, only select the first instance of the VM name for reporting and export purposes.

In the Re-Configure script, update the headers information to use the JSON headers variable.